### PR TITLE
Activate by default

### DIFF
--- a/keymaps/org.cson
+++ b/keymaps/org.cson
@@ -8,10 +8,10 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.workspace':
-  'ctrl-alt-o': 'org:toggle'
+  'alt-o': 'org:toggle'
 '.workspace .editor:not(.mini)':
-  'cmd-enter': 'org:insert-headline-empty-respect-content'
-  'cmd-shift-enter': 'org:insert-headline-todo-respect-content'
+  'ctrl-enter': 'org:insert-headline-empty-respect-content'
+  'alt-enter': 'org:insert-headline-todo-respect-content'
   'alt-right': 'org:demote-headline'
   'alt-left': 'org:promote-headline'
   'alt-shift-right': 'org:demote-tree'

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "main": "./lib/org",
   "version": "0.2.5",
   "description": "Very early stage of Org-Mode for atom.io",
-  "activationEvents": [
-    "org:toggle"
-  ],
   "repository": "https://github.com/wolfgang/org",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
If you use this package, use it, if you don't disable it.  I don't want
to press a key cord every time I go to use it.

and

more practical key-bindings, better on windows.

This fixes https://github.com/wolfgang/org/issues/1